### PR TITLE
Add experimental support for imports in `evaluate`

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -23,10 +23,12 @@ import {remarkMdx} from './remark-mdx.js'
  * @property {PluggableList} [recmaPlugins] List of recma (esast, JavaScript) plugins
  * @property {PluggableList} [remarkPlugins] List of remark (mdast, markdown) plugins
  * @property {PluggableList} [rehypePlugins] List of rehype (hast, HTML) plugins
- * @property {boolean} [_contain=false] Semihidden option
  * @property {boolean} [_async=false] Semihidden option
+ * @property {string} [_baseUrl] Semihidden option
+ * @property {boolean} [_contain=false] Semihidden option
  *
- * @typedef {Omit<RecmaDocumentOptions & RecmaStringifyOptions & RecmaJsxRewriteOptions & BaseProcessorOptions, "_contain" | "_async"> } ProcessorOptions
+ * @typedef {Omit<RecmaDocumentOptions & RecmaStringifyOptions & RecmaJsxRewriteOptions, "_async" | "_contain" | "_baseUrl">} PluginOptions
+ * @typedef {BaseProcessorOptions & PluginOptions} ProcessorOptions
  */
 
 /**

--- a/lib/core.js
+++ b/lib/core.js
@@ -25,7 +25,7 @@ import {remarkMdx} from './remark-mdx.js'
  * @property {PluggableList} [rehypePlugins] List of rehype (hast, HTML) plugins
  * @property {boolean} [_contain=false] Semihidden option
  *
- * @typedef {Omit<RecmaDocumentOptions & RecmaStringifyOptions & RecmaJsxRewriteOptions & BaseProcessorOptions, "contain"> } ProcessorOptions
+ * @typedef {Omit<RecmaDocumentOptions & RecmaStringifyOptions & RecmaJsxRewriteOptions & BaseProcessorOptions, "_contain"> } ProcessorOptions
  */
 
 /**
@@ -62,7 +62,7 @@ export function compileSync(file, options) {
  */
 export function createProcessor(options = {}) {
   var {
-    _contain: contain,
+    _contain,
     jsx,
     providerImportSource,
     recmaPlugins,
@@ -91,11 +91,11 @@ export function createProcessor(options = {}) {
       .use(rehypeMarkAndUnravel)
       .use(rehypePlugins)
       .use(rehypeRecma)
-      .use(recmaDocument, {...otherOptions, contain})
+      .use(recmaDocument, {...otherOptions, _contain})
       // @ts-ignore recma transformer uses an esast node rather than a unist node
-      .use(recmaJsxRewrite, {providerImportSource, contain})
+      .use(recmaJsxRewrite, {providerImportSource, _contain})
       // @ts-ignore recma transformer uses an esast node rather than a unist node
-      .use(jsx ? undefined : recmaJsxBuild, {contain})
+      .use(jsx ? undefined : recmaJsxBuild, {_contain})
       // @ts-ignore recma compiler is seen as a transformer
       .use(recmaStringify, {SourceMapGenerator})
       .use(recmaPlugins)

--- a/lib/core.js
+++ b/lib/core.js
@@ -24,8 +24,9 @@ import {remarkMdx} from './remark-mdx.js'
  * @property {PluggableList} [remarkPlugins] List of remark (mdast, markdown) plugins
  * @property {PluggableList} [rehypePlugins] List of rehype (hast, HTML) plugins
  * @property {boolean} [_contain=false] Semihidden option
+ * @property {boolean} [_async=false] Semihidden option
  *
- * @typedef {Omit<RecmaDocumentOptions & RecmaStringifyOptions & RecmaJsxRewriteOptions & BaseProcessorOptions, "_contain"> } ProcessorOptions
+ * @typedef {Omit<RecmaDocumentOptions & RecmaStringifyOptions & RecmaJsxRewriteOptions & BaseProcessorOptions, "_contain" | "_async"> } ProcessorOptions
  */
 
 /**
@@ -63,6 +64,7 @@ export function compileSync(file, options) {
 export function createProcessor(options = {}) {
   var {
     _contain,
+    _async,
     jsx,
     providerImportSource,
     recmaPlugins,
@@ -91,7 +93,7 @@ export function createProcessor(options = {}) {
       .use(rehypeMarkAndUnravel)
       .use(rehypePlugins)
       .use(rehypeRecma)
-      .use(recmaDocument, {...otherOptions, _contain})
+      .use(recmaDocument, {...otherOptions, _contain, _async})
       // @ts-ignore recma transformer uses an esast node rather than a unist node
       .use(recmaJsxRewrite, {providerImportSource, _contain})
       // @ts-ignore recma transformer uses an esast node rather than a unist node

--- a/lib/core.js
+++ b/lib/core.js
@@ -65,8 +65,8 @@ export function compileSync(file, options) {
  */
 export function createProcessor(options = {}) {
   var {
-    _contain,
     _async,
+    _contain,
     jsx,
     providerImportSource,
     recmaPlugins,
@@ -95,7 +95,7 @@ export function createProcessor(options = {}) {
       .use(rehypeMarkAndUnravel)
       .use(rehypePlugins)
       .use(rehypeRecma)
-      .use(recmaDocument, {...otherOptions, _contain, _async})
+      .use(recmaDocument, {...otherOptions, _async, _contain})
       // @ts-ignore recma transformer uses an esast node rather than a unist node
       .use(recmaJsxRewrite, {providerImportSource, _contain})
       // @ts-ignore recma transformer uses an esast node rather than a unist node

--- a/lib/evaluate.js
+++ b/lib/evaluate.js
@@ -1,5 +1,8 @@
 import {compile, compileSync} from './core.js'
 
+/* c8 ignore next 1 */
+async function f() {}
+
 /**
  * @typedef {import("vfile").VFileCompatible} VFileCompatible
  * @typedef {import('./core.js').BaseProcessorOptions} BaseProcessorOptions
@@ -10,7 +13,7 @@ import {compile, compileSync} from './core.js'
  * @property {*} jsxs Function to generate an element with dynamic children
  * @property {*} [useMDXComponents] Function to get `MDXComponents` from context
  *
- * @typedef {Omit<BaseProcessorOptions, "jsx" | "_contain"> } ProcessorOptions
+ * @typedef {Omit<BaseProcessorOptions, "jsx" | "_contain" | "_async"> } ProcessorOptions
  * @typedef {ProcessorOptions & RunnerOptions} ProcessorAndRunnerOptions
  *
  * @typedef {{ [name: string]: any }} ComponentMap
@@ -26,11 +29,13 @@ import {compile, compileSync} from './core.js'
  * @return {Promise<ExportMap>}
  */
 export async function evaluate(file, options) {
-  var config = split(options)
+  var config = split({...options, _async: true})
   // What is this?
   // V8 on Node 12 can’t handle `eval` for collecting coverage, apparently…
-  /* c8 ignore next 2 */
-  return new Function(String(await compile(file, config.compile)))(config.run)
+  /* c8 ignore next 4 */
+  return new f.constructor(String(await compile(file, config.compile)))(
+    config.run
+  )
 }
 
 /**
@@ -58,7 +63,8 @@ function split(options) {
     recmaPlugins,
     rehypePlugins,
     remarkPlugins,
-    useMDXComponents
+    useMDXComponents,
+    _async
   } = options || {}
 
   if (!Fragment) throw new Error('Expected `Fragment` given to `evaluate`')
@@ -68,6 +74,7 @@ function split(options) {
   return {
     compile: {
       _contain: true,
+      _async,
       providerImportSource: useMDXComponents ? '#' : undefined,
       recmaPlugins,
       rehypePlugins,

--- a/lib/evaluate.js
+++ b/lib/evaluate.js
@@ -1,7 +1,7 @@
 import {compile, compileSync} from './core.js'
 
 /* c8 ignore next 1 */
-async function f() {}
+var AsyncFunction = Object.getPrototypeOf(async function () {}).constructor
 
 /**
  * @typedef {import("vfile").VFileCompatible} VFileCompatible
@@ -13,12 +13,16 @@ async function f() {}
  * @property {*} jsxs Function to generate an element with dynamic children
  * @property {*} [useMDXComponents] Function to get `MDXComponents` from context
  *
- * @typedef {Omit<BaseProcessorOptions, "jsx" | "_contain" | "_async"> } ProcessorOptions
- * @typedef {ProcessorOptions & RunnerOptions} ProcessorAndRunnerOptions
+ * @typedef {Omit<BaseProcessorOptions, "jsx" | "_async" | "_contain" | "_baseUrl"> } ProcessorOptions
  *
- * @typedef {{ [name: string]: any }} ComponentMap
- * @typedef {{ [props: string]: any, components?: ComponentMap }} MDXContentProps
- * @typedef {{ [exports: string]: unknown, default: (props: MDXContentProps) => any }} ExportMap
+ * @typedef ExtraOptions
+ * @property {string} baseUrl URL to resolve imports from (typically: pass `import.meta.url`)
+ *
+ * @typedef {ProcessorOptions & RunnerOptions & ExtraOptions} ProcessorAndRunnerOptions
+ *
+ * @typedef {{[name: string]: any}} ComponentMap
+ * @typedef {{[props: string]: any, components?: ComponentMap}} MDXContentProps
+ * @typedef {{[exports: string]: unknown, default: (props: MDXContentProps) => any}} ExportMap
  */
 
 /**
@@ -29,13 +33,14 @@ async function f() {}
  * @return {Promise<ExportMap>}
  */
 export async function evaluate(file, options) {
-  var config = split({...options, _async: true})
+  var config = split(options)
+  var _async = Boolean(config.compile._baseUrl)
   // What is this?
   // V8 on Node 12 can’t handle `eval` for collecting coverage, apparently…
   /* c8 ignore next 4 */
-  return new f.constructor(String(await compile(file, config.compile)))(
-    config.run
-  )
+  return new AsyncFunction(
+    String(await compile(file, {...config.compile, _async}))
+  )(config.run)
 }
 
 /**
@@ -64,7 +69,7 @@ function split(options) {
     rehypePlugins,
     remarkPlugins,
     useMDXComponents,
-    _async
+    baseUrl
   } = options || {}
 
   if (!Fragment) throw new Error('Expected `Fragment` given to `evaluate`')
@@ -74,7 +79,7 @@ function split(options) {
   return {
     compile: {
       _contain: true,
-      _async,
+      _baseUrl: baseUrl,
       providerImportSource: useMDXComponents ? '#' : undefined,
       recmaPlugins,
       rehypePlugins,

--- a/lib/recma-document.js
+++ b/lib/recma-document.js
@@ -5,7 +5,7 @@ import {create} from './util/estree-util-create.js'
 
 /**
  * @typedef RecmaDocumentOptions
- * @property {boolean} [contain] Semihidden option which here results in failing on imports and adding a top-level return statement instead of an export.
+ * @property {boolean} [_contain] Semihidden option which here results in failing on imports and adding a top-level return statement instead of an export.
  * @property {string} [pragma='React.createElement'] Pragma for JSX (used in classic runtime)
  * @property {string} [pragmaFrag='React.Fragment'] Pragma for JSX fragments (used in classic runtime)
  * @property {string} [pragmaImportSource='react'] Where to import the identifier of `pragma` from (used in classic runtime)
@@ -18,9 +18,9 @@ import {create} from './util/estree-util-create.js'
  *
  * @param {RecmaDocumentOptions} [options]
  */
-export function recmaDocument(options) {
+export function recmaDocument(options = {}) {
   var {
-    contain,
+    _contain,
     pragma = 'React.createElement',
     pragmaFrag = 'React.Fragment',
     pragmaImportSource = 'react',
@@ -121,7 +121,7 @@ export function recmaDocument(options) {
       // export {a as default, b} from "c"
       // ```
       else if (child.type === 'ExportNamedDeclaration' && child.source) {
-        if (contain) {
+        if (_contain) {
           file.fail(
             'Cannot use `export … from` in contained MDX',
             positionFromEstree(child),
@@ -178,13 +178,13 @@ export function recmaDocument(options) {
         if (child.specifiers.length > 0) {
           replacement.push(child)
         }
-      } else if (child.type === 'ExportAllDeclaration' && contain) {
+      } else if (child.type === 'ExportAllDeclaration' && _contain) {
         file.fail(
           'Cannot use `export * from` in contained MDX',
           positionFromEstree(child),
           'recma-document:contain-export'
         )
-      } else if (child.type === 'ExportNamedDeclaration' && contain) {
+      } else if (child.type === 'ExportNamedDeclaration' && _contain) {
         if (child.declaration) {
           replacement.push(child.declaration)
 
@@ -212,7 +212,7 @@ export function recmaDocument(options) {
       } else if (
         (child.type === 'ImportNamespaceSpecifier' ||
           child.type === 'ImportDeclaration') &&
-        contain
+        _contain
       ) {
         file.fail(
           'Cannot use `import` in contained MDX',
@@ -236,7 +236,7 @@ export function recmaDocument(options) {
       replacement.push(createMdxContent())
     }
 
-    if (contain) {
+    if (_contain) {
       exportedIdentifiers.push(['MDXContent', 'default'])
       replacement.push(
         u('ReturnStatement', {

--- a/lib/recma-document.js
+++ b/lib/recma-document.js
@@ -21,6 +21,7 @@ import {create} from './util/estree-util-create.js'
 export function recmaDocument(options = {}) {
   var {
     _contain,
+    _async,
     pragma = 'React.createElement',
     pragmaFrag = 'React.Fragment',
     pragmaImportSource = 'react',

--- a/lib/recma-document.js
+++ b/lib/recma-document.js
@@ -6,6 +6,8 @@ import {create} from './util/estree-util-create.js'
 /**
  * @typedef RecmaDocumentOptions
  * @property {boolean} [_contain] Semihidden option which here results in failing on imports and adding a top-level return statement instead of an export.
+ * @property {boolean} [_async] Semihidden option which here turns import statements (and `export from`s) into import expressions (if `_baseUrl` is also set)
+ * @property {string} [_baseUrl] Semihidden option which here turns import statements (and `export from`s) into import expressions
  * @property {string} [pragma='React.createElement'] Pragma for JSX (used in classic runtime)
  * @property {string} [pragmaFrag='React.Fragment'] Pragma for JSX fragments (used in classic runtime)
  * @property {string} [pragmaImportSource='react'] Where to import the identifier of `pragma` from (used in classic runtime)
@@ -21,6 +23,7 @@ import {create} from './util/estree-util-create.js'
 export function recmaDocument(options = {}) {
   var {
     _contain,
+    _baseUrl,
     _async,
     pragma = 'React.createElement',
     pragmaFrag = 'React.Fragment',
@@ -38,8 +41,6 @@ export function recmaDocument(options = {}) {
     var layout
     var content
     var child
-    var declaration
-    var specifier
 
     if (jsxRuntime) {
       pragmas.push('@jsxRuntime ' + jsxRuntime)
@@ -68,7 +69,7 @@ export function recmaDocument(options = {}) {
         )
       }
 
-      replacement.push(
+      handleImport(
         u('ImportDeclaration', {
           specifiers: [
             u('ImportDefaultSpecifier', {
@@ -112,114 +113,89 @@ export function recmaDocument(options = {}) {
           })
         )
       }
-      // Look for default “reexports”.
-      //
       // ```js
-      // export {default} from "a"
-      // export {default as a} from "b"
-      // export {default as a, b} from "c"
-      // export {a as default} from "b"
-      // export {a as default, b} from "c"
+      // export function a() {}
+      // export {a, b as c}
+      // export {a, b as c} from "d"
       // ```
-      else if (child.type === 'ExportNamedDeclaration' && child.source) {
-        if (_contain) {
-          file.fail(
-            'Cannot use `export … from` in contained MDX',
-            positionFromEstree(child),
-            'recma-document:contain-export'
-          )
-        }
+      else if (child.type === 'ExportNamedDeclaration') {
+        // ```js
+        // export {a, b as c} from "d"
+        // ```
+        if (child.source) {
+          // Remove `default` or `as default`, but not `default as`, specifier.
+          child.specifiers = child.specifiers.filter(function (specifier) {
+            if (specifier.exported.name === 'default') {
+              if (layout) {
+                file.fail(
+                  'Cannot specify multiple layouts (previous: ' +
+                    stringifyPosition(positionFromEstree(layout)) +
+                    ')',
+                  positionFromEstree(child),
+                  'recma-document:duplicate-layout'
+                )
+              }
 
-        // Remove `default` or `as default`, but not `default as`, specifier.
-        child.specifiers = child.specifiers.filter(function (specifier) {
-          if (specifier.exported.name === 'default') {
-            if (layout) {
-              file.fail(
-                'Cannot specify multiple layouts (previous: ' +
-                  stringifyPosition(positionFromEstree(layout)) +
-                  ')',
-                positionFromEstree(child),
-                'recma-document:duplicate-layout'
-              )
-            }
+              layout = specifier
 
-            layout = specifier
-
-            // Make it just an import: `import MDXLayout from "..."`.
-            replacement.push(
-              create(
-                specifier,
-                u('ImportDeclaration', {
-                  specifiers: [
-                    // Default as default / something else as default.
-                    specifier.local.name === 'default'
-                      ? u('ImportDefaultSpecifier', {
-                          local: u('Identifier', {name: 'MDXLayout'})
-                        })
-                      : create(
-                          specifier.local,
-                          u('ImportSpecifier', {
-                            imported: specifier.local,
+              // Make it just an import: `import MDXLayout from "..."`.
+              handleImport(
+                create(
+                  specifier,
+                  u('ImportDeclaration', {
+                    specifiers: [
+                      // Default as default / something else as default.
+                      specifier.local.name === 'default'
+                        ? u('ImportDefaultSpecifier', {
                             local: u('Identifier', {name: 'MDXLayout'})
                           })
-                        )
-                  ],
-                  source: create(child.source, u('Literal', child.source.value))
-                })
+                        : create(
+                            specifier.local,
+                            u('ImportSpecifier', {
+                              imported: specifier.local,
+                              local: u('Identifier', {name: 'MDXLayout'})
+                            })
+                          )
+                    ],
+                    source: create(
+                      child.source,
+                      u('Literal', child.source.value)
+                    )
+                  })
+                )
               )
-            )
 
-            return false
-          }
-
-          return true
-        })
-
-        // If there are other things imported, keep it.
-        if (child.specifiers.length > 0) {
-          replacement.push(child)
-        }
-      } else if (child.type === 'ExportAllDeclaration' && _contain) {
-        file.fail(
-          'Cannot use `export * from` in contained MDX',
-          positionFromEstree(child),
-          'recma-document:contain-export'
-        )
-      } else if (child.type === 'ExportNamedDeclaration' && _contain) {
-        if (child.declaration) {
-          replacement.push(child.declaration)
-
-          if (
-            child.declaration.type === 'FunctionDeclaration' ||
-            child.declaration.type === 'ClassDeclaration'
-          ) {
-            exportedIdentifiers.push(child.declaration.id.name)
-          }
-          // Must be a variable declaration: other things can’t be exported with
-          // ESM.
-          else {
-            for (declaration of child.declaration.declarations) {
-              exportedIdentifiers.push(declaration.id.name)
+              return false
             }
-          }
-        } else {
-          for (specifier of child.specifiers) {
-            exportedIdentifiers.push([
-              specifier.local.name,
-              specifier.exported.name
-            ])
+
+            return true
+          })
+
+          // If there are other things imported, keep it.
+          if (child.specifiers.length > 0) {
+            handleExport(child)
           }
         }
+        // ```js
+        // export function a() {}
+        // export class A {}
+        // export const a = 1
+        // export {a, b as c}
+        // ```
+        else {
+          handleExport(child)
+        }
+      }
+      // ```js
+      // export * from "a"
+      // ```
+      else if (child.type === 'ExportAllDeclaration') {
+        handleExport(child)
       } else if (
-        (child.type === 'ImportNamespaceSpecifier' ||
-          child.type === 'ImportDeclaration') &&
-        _contain
+        child.type === 'ImportNamespaceSpecifier' ||
+        child.type === 'ImportDeclaration'
       ) {
-        file.fail(
-          'Cannot use `import` in contained MDX',
-          positionFromEstree(child),
-          'recma-document:contain-import'
-        )
+        handleImport(child)
       } else if (
         child.type === 'ExpressionStatement' &&
         (child.expression.type === 'JSXFragment' ||
@@ -227,6 +203,11 @@ export function recmaDocument(options = {}) {
       ) {
         content = true
         replacement.push(createMdxContent(child.expression))
+        // The following catch-all branch is because plugins might’ve added
+        // other things.
+        // Normally, we only have import/export/jsx, but just add whatever’s
+        // there.
+        /* c8 ignore next 3 */
       } else {
         replacement.push(child)
       }
@@ -262,6 +243,106 @@ export function recmaDocument(options = {}) {
     }
 
     tree.body = replacement
+
+    function handleImport(node) {
+      if (_contain || _async) {
+        handleImportExportFrom(node)
+      } else {
+        replacement.push(node)
+      }
+    }
+
+    function handleExport(node) {
+      var child
+
+      if (_contain) {
+        // ```js
+        // export function a() {}
+        // export class A {}
+        // export const a = 1
+        // ```
+        if (node.declaration) {
+          replacement.push(node.declaration)
+
+          if (
+            node.declaration.type === 'FunctionDeclaration' ||
+            node.declaration.type === 'ClassDeclaration'
+          ) {
+            exportedIdentifiers.push(node.declaration.id.name)
+          }
+          // Must be a variable declaration: other things can’t be exported with
+          // ESM.
+          else {
+            for (child of node.declaration.declarations) {
+              exportedIdentifiers.push(child.id.name)
+            }
+          }
+        } else if (node.source) {
+          handleImportExportFrom(node)
+        }
+
+        // ```js
+        // export {a, b as c}
+        // export {a, b as c} from "d"
+        // ```
+        if (node.specifiers) {
+          for (child of node.specifiers) {
+            exportedIdentifiers.push(
+              child.local.name === child.exported.name
+                ? child.local.name
+                : [child.local.name, child.exported.name]
+            )
+          }
+        }
+      } else {
+        replacement.push(node)
+      }
+    }
+
+    function handleImportExportFrom(node) {
+      var expression
+
+      if (!_async) {
+        file.fail(
+          'Cannot use `import` or `export … from` in `evaluateSync` or `evaluate` w/o passing `baseUrl`: use `compile`, `compileSync`, or use `evaluate` and pass a `baseUrl`',
+          positionFromEstree(child),
+          'recma-document:contain-export'
+        )
+      }
+
+      expression = create(
+        node,
+        u('ImportExpression', {
+          source: create(node.source, u('Literal', {value: node.source.value}))
+        })
+      )
+
+      expression.source.value = new URL(expression.source.value, _baseUrl)
+
+      replacement.push(
+        u('VariableDeclaration', {
+          kind: 'const',
+          declarations: [
+            u('VariableDeclarator', {
+              // To do: externalise this w/ the one in `jsx-build`.
+              id: u('ObjectPattern', {
+                properties: node.specifiers.map((specifier) => {
+                  // @ts-ignore assume specifier is not a default export
+                  var key = specifier.imported || specifier.exported
+                  return u('Property', {
+                    kind: 'init',
+                    shorthand: key.name === specifier.local.name,
+                    key,
+                    value: specifier.local
+                  })
+                })
+              }),
+              init: u('AwaitExpression', {argument: expression})
+            })
+          ]
+        })
+      )
+    }
   }
 
   function createMdxContent(content) {

--- a/lib/recma-jsx-build.js
+++ b/lib/recma-jsx-build.js
@@ -5,7 +5,7 @@ import u from 'unist-builder'
  * @typedef {import("estree").Program} Program
  *
  * @typedef RecmaJsxBuildOptions
- * @property {boolean} [contain] Semihidden option which here results in getting the automatic runtime from `arguments[0]` instead of importing it
+ * @property {boolean} [_contain] Semihidden option which here results in getting the automatic runtime from `arguments[0]` instead of importing it
  */
 
 /**
@@ -14,7 +14,9 @@ import u from 'unist-builder'
  *
  * @param {RecmaJsxBuildOptions} [options]
  */
-export function recmaJsxBuild({contain}) {
+export function recmaJsxBuild(options = {}) {
+  var {_contain} = options
+
   return transform
 
   /**
@@ -26,7 +28,7 @@ export function recmaJsxBuild({contain}) {
     // In contain mode, replace the import that was just generated, and get
     // `jsx`, `jsxs`, and `Fragment` from `arguments[0]` instead.
     if (
-      contain &&
+      _contain &&
       tree.body[0] &&
       tree.body[0].type === 'ImportDeclaration' &&
       typeof tree.body[0].source.value === 'string' &&

--- a/lib/recma-jsx-rewrite.js
+++ b/lib/recma-jsx-rewrite.js
@@ -53,6 +53,7 @@ export function recmaJsxRewrite(options = {}) {
       var name
       var scope
 
+      // To do: async functions?
       if (
         node.type === 'FunctionDeclaration' ||
         node.type === 'FunctionExpression' ||
@@ -126,6 +127,7 @@ export function recmaJsxRewrite(options = {}) {
       var scope
       var name
 
+      // To do: async functions?
       if (
         node.type === 'FunctionDeclaration' ||
         node.type === 'FunctionExpression' ||

--- a/lib/recma-jsx-rewrite.js
+++ b/lib/recma-jsx-rewrite.js
@@ -7,7 +7,7 @@ import u from 'unist-builder'
  * @typedef {import("estree").Program} Program
  *
  * @typedef RecmaJsxRewriteOptions
- * @property {boolean} [contain] Semihidden option which here results in getting `useMDXComponents` from `arguments[0]` instead of importing it
+ * @property {boolean} [_contain] Semihidden option which here results in getting `useMDXComponents` from `arguments[0]` instead of importing it
  * @property {string} [providerImportSource] Place to import a provider from
  */
 
@@ -20,7 +20,8 @@ import u from 'unist-builder'
  *
  * @param {RecmaJsxRewriteOptions} options
  */
-export function recmaJsxRewrite({providerImportSource, contain} = {}) {
+export function recmaJsxRewrite(options = {}) {
+  var {providerImportSource, _contain} = options
   return transform
 
   /**
@@ -45,7 +46,7 @@ export function recmaJsxRewrite({providerImportSource, contain} = {}) {
     // If a provider is used (and can be used), import it.
     if (importProvider) {
       // @ts-ignore it is assumed this is not an identifier
-      tree.body.unshift(createImportProvider(providerImportSource, contain))
+      tree.body.unshift(createImportProvider(providerImportSource, _contain))
     }
 
     function onenter(node) {

--- a/package.json
+++ b/package.json
@@ -100,8 +100,8 @@
   },
   "scripts": {
     "format": "remark . -qfo && prettier . -w --loglevel warn && xo --fix",
-    "test-api": "node --experimental-loader=./esm-loader.js test/index.js && node test/register.cjs",
-    "test-coverage": "c8 --check-coverage --branches 100 --functions 100 --lines 100 --statements 100 --reporter lcov node --experimental-modules --experimental-loader=./esm-loader.js test/index.js",
+    "test-api": "node --no-warnings --experimental-loader=./esm-loader.js test/index.js && node test/register.cjs",
+    "test-coverage": "c8 --check-coverage --branches 100 --functions 100 --lines 100 --statements 100 --reporter lcov node --no-warnings --experimental-loader=./esm-loader.js test/index.js",
     "prebuild": "rimraf \"*.d.ts\" \"{lib,test}/**/*.d.ts\"",
     "build": "tsc",
     "test": "npm run format && npm run test-coverage && npm run build",

--- a/readme.md
+++ b/readme.md
@@ -53,6 +53,7 @@ time.
 *   [👩‍🔬 lab](#-lab)
     *   [Importing `.mdx` files directly](#importing-mdx-files-directly)
     *   [Requiring `.mdx` files directly](#requiring-mdx-files-directly)
+    *   [Imports in `evaluate`](#imports-in-evaluate)
 *   [MDX syntax](#mdx-syntax)
     *   [Markdown](#markdown)
     *   [JSX](#jsx)
@@ -565,6 +566,8 @@ and then run with Node or bundle with [esbuild][]/[Rollup][]/[webpack][].
 But if you trust your content and know that it doesn’t contain imports,
 `evaluate` can work.
 
+It *does* support top-level await!
+
 ###### `file`
 
 See [`compile`][compile].
@@ -612,6 +615,10 @@ var {default: Content} = await evaluate('# hi', {...provider, ...runtime, ...oth
 ```
 
 </details>
+
+###### `options.baseUrl`
+
+See [Imports in `evaluate`](#imports-in-evaluate) in [👩‍🔬 lab][lab]!
 
 ###### Returns
 
@@ -726,6 +733,28 @@ Currently, no options are supported.
 
 The register hook uses [`evaluate`][eval].
 That means `import` (and `export … from`) are not supported in `.mdx` files.
+
+### Imports in `evaluate`
+
+`evaluate` supports top-level await.
+So, as a follow up, **xdm** can turn import statements (`import {x} from 'y'`)
+into import expressions (`const {x} = await import('y')`).
+
+There’s one catch: where to import from?
+You must pass a `baseUrl` to [`evaluate`][eval].
+Typically, you should use `import.meta.url`.
+
+Assuming `example.mdx` from [§ Use][use] exists, and our script `example.cjs`
+looks as follows:
+
+```js
+import * as runtime from 'react/jsx-runtime.js'
+import {evaluate} from 'xdm'
+
+var {x} = await evaluate('export {x} from "./data.js"', {...runtime, baseUrl: import.meta.url})
+
+console.log(x)
+```
 
 ## MDX syntax
 

--- a/test/evaluate.js
+++ b/test/evaluate.js
@@ -51,6 +51,22 @@ test('xdm (evaluate)', async function (t) {
     'should evaluate (sync)'
   )
 
+  t.equal(
+    renderToStaticMarkup(
+      React.createElement(
+        (
+          await evaluate(
+            'import {number} from "./context/data.js"\n\n{number}',
+            // @ts-ignore runtime.js does not have a typing
+            {baseUrl: import.meta.url, ...runtime}
+          )
+        ).default
+      )
+    ),
+    '3.14',
+    'should support an `import from` w/ `evaluate` and given a `baseUrl`'
+  )
+
   // @ts-ignore runtime.js does not have a typing
   var mod = await evaluate('export const a = 1\n\n{a}', runtime)
 
@@ -123,8 +139,32 @@ test('xdm (evaluate)', async function (t) {
       // @ts-ignore runtime.js does not have a typing
       evaluateSync('export {a} from "b"', runtime)
     },
-    /Cannot use `export … from` in contained MDX/,
+    /Cannot use `import` or `export … from` in `evaluateSync`/,
     'should throw on an export from'
+  )
+
+  t.equal(
+    (
+      await evaluate(
+        'export {number} from "./context/data.js"',
+        // @ts-ignore runtime.js does not have a typing
+        {baseUrl: import.meta.url, ...runtime}
+      )
+    ).number,
+    3.14,
+    'should support an `export from` w/ `evaluate` and given a `baseUrl`'
+  )
+
+  t.equal(
+    (
+      await evaluate(
+        'import {number} from "./context/data.js"\nexport {number}',
+        // @ts-ignore runtime.js does not have a typing
+        {baseUrl: import.meta.url, ...runtime}
+      )
+    ).number,
+    3.14,
+    'should support an `export` w/ `evaluate` and given a `baseUrl`'
   )
 
   t.throws(
@@ -132,7 +172,7 @@ test('xdm (evaluate)', async function (t) {
       // @ts-ignore runtime.js does not have a typing
       evaluateSync('export * from "a"', runtime)
     },
-    /Cannot use `export \* from` in contained MDX/,
+    /Cannot use `import` or `export … from` in `evaluateSync`/,
     'should throw on an export all from'
   )
 
@@ -141,7 +181,7 @@ test('xdm (evaluate)', async function (t) {
       // @ts-ignore runtime.js does not have a typing
       evaluateSync('import {a} from "b"', runtime)
     },
-    /Cannot use `import` in contained MDX/,
+    /Cannot use `import` or `export … from` in `evaluateSync`/,
     'should throw on an import'
   )
 
@@ -150,7 +190,7 @@ test('xdm (evaluate)', async function (t) {
       // @ts-ignore runtime.js does not have a typing
       evaluateSync('import a from "b"', runtime)
     },
-    /Cannot use `import` in contained MDX/,
+    /Cannot use `import` or `export … from` in `evaluateSync`/,
     'should throw on an import default'
   )
 


### PR DESCRIPTION
Closes GH-16.

I did miss, in that issue, that a base URL would be needed. So this uses that.