### PR TITLE
Add docs on `pageExtensions` for Next

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1404,9 +1404,11 @@ in a `next.config.js` file like so:
 
 ```js
 module.exports = {
+  // Make sure to include 'mdx' files as pages
+  pageExtensions: ['mdx', 'tsx', 'ts', 'jsx', 'js'],
   webpack(config) {
     config.module.rules.push({
-      test: /\.mdx/,
+      test: /\.mdx$/,
       use: [{loader: 'xdm/webpack.cjs', options: {}}]
     })
 

--- a/readme.md
+++ b/readme.md
@@ -1406,6 +1406,7 @@ in a `next.config.js` file like so:
 module.exports = {
   // Support MDX files as pages:
   pageExtensions: ['mdx', 'tsx', 'ts', 'jsx', 'js'],
+  // Support loading `.mdx`:
   webpack(config) {
     config.module.rules.push({
       test: /\.mdx$/,

--- a/readme.md
+++ b/readme.md
@@ -1404,7 +1404,7 @@ in a `next.config.js` file like so:
 
 ```js
 module.exports = {
-  // Make sure to include 'mdx' files as pages
+  // Support MDX files as pages:
   pageExtensions: ['mdx', 'tsx', 'ts', 'jsx', 'js'],
   webpack(config) {
     config.module.rules.push({


### PR DESCRIPTION
As mentioned in #27, this is a key step to make Next.js work with MDX files.