### PR TITLE
Add `useDynamicImport` option, stable `baseUrl`

### DIFF
--- a/lib/plugin/recma-document.js
+++ b/lib/plugin/recma-document.js
@@ -6,8 +6,9 @@ import {specifiersToObjectPattern} from '../util/estree-util-specifiers-to-objec
 
 /**
  * @typedef RecmaDocumentOptions
- * @property {'program' | 'function-body'} [outputFormat='program'] Whether to use import and export statements or get values from `arguments` and return things
- * @property {string} [baseUrl] In `evaluate`, resolve relative import statements (and `export from`s) relative to this URL
+ * @property {'program' | 'function-body'} [outputFormat='program'] Whether to use either `import` and `export` statements to get the runtime (and optionally provider) and export the content, or get values from `arguments` and return things
+ * @property {boolean} [useDynamicImport=false] Whether to keep `import` (and `export … from`) statements or compile them to dynamic `import()` instead
+ * @property {string} [baseUrl] Resolve relative `import` (and `export … from`) relative to this URL
  * @property {string} [pragma='React.createElement'] Pragma for JSX (used in classic runtime)
  * @property {string} [pragmaFrag='React.Fragment'] Pragma for JSX fragments (used in classic runtime)
  * @property {string} [pragmaImportSource='react'] Where to import the identifier of `pragma` from (used in classic runtime)
@@ -23,7 +24,8 @@ import {specifiersToObjectPattern} from '../util/estree-util-specifiers-to-objec
 export function recmaDocument(options = {}) {
   var {
     baseUrl,
-    outputFormat,
+    useDynamicImport,
+    outputFormat = 'program',
     pragma = 'React.createElement',
     pragmaFrag = 'React.Fragment',
     pragmaImportSource = 'react',
@@ -41,6 +43,7 @@ export function recmaDocument(options = {}) {
     var exportedIdentifiers = []
     var replacement = []
     var pragmas = []
+    var exportAllCount = 0
     var layout
     var content
     var child
@@ -72,7 +75,7 @@ export function recmaDocument(options = {}) {
         )
       }
 
-      handleImport(
+      handleEsm(
         u('ImportDeclaration', {
           specifiers: [
             u('ImportDefaultSpecifier', {
@@ -117,88 +120,75 @@ export function recmaDocument(options = {}) {
         )
       }
       // ```js
-      // export function a() {}
-      // export {a, b as c}
       // export {a, b as c} from 'd'
       // ```
-      else if (child.type === 'ExportNamedDeclaration') {
-        // ```js
-        // export {a, b as c} from 'd'
-        // ```
-        if (child.source) {
-          // Remove `default` or `as default`, but not `default as`, specifier.
-          child.specifiers = child.specifiers.filter(function (specifier) {
-            if (specifier.exported.name === 'default') {
-              if (layout) {
-                file.fail(
-                  'Cannot specify multiple layouts (previous: ' +
-                    stringifyPosition(positionFromEstree(layout)) +
-                    ')',
-                  positionFromEstree(child),
-                  'recma-document:duplicate-layout'
-                )
-              }
-
-              layout = specifier
-
-              // Make it just an import: `import MDXLayout from '…'`.
-              handleImport(
-                create(
-                  specifier,
-                  u('ImportDeclaration', {
-                    specifiers: [
-                      // Default as default / something else as default.
-                      specifier.local.name === 'default'
-                        ? u('ImportDefaultSpecifier', {
-                            local: u('Identifier', {name: 'MDXLayout'})
-                          })
-                        : create(
-                            specifier.local,
-                            u('ImportSpecifier', {
-                              imported: specifier.local,
-                              local: u('Identifier', {name: 'MDXLayout'})
-                            })
-                          )
-                    ],
-                    source: create(
-                      child.source,
-                      u('Literal', {value: child.source.value})
-                    )
-                  })
-                )
+      else if (child.type === 'ExportNamedDeclaration' && child.source) {
+        // Remove `default` or `as default`, but not `default as`, specifier.
+        child.specifiers = child.specifiers.filter(function (specifier) {
+          if (specifier.exported.name === 'default') {
+            if (layout) {
+              file.fail(
+                'Cannot specify multiple layouts (previous: ' +
+                  stringifyPosition(positionFromEstree(layout)) +
+                  ')',
+                positionFromEstree(child),
+                'recma-document:duplicate-layout'
               )
-
-              return false
             }
 
-            return true
-          })
+            layout = specifier
 
-          // If there are other things imported, keep it.
-          if (child.specifiers.length > 0) {
-            handleExport(child)
+            // Make it just an import: `import MDXLayout from '…'`.
+            handleEsm(
+              create(
+                specifier,
+                u('ImportDeclaration', {
+                  specifiers: [
+                    // Default as default / something else as default.
+                    specifier.local.name === 'default'
+                      ? u('ImportDefaultSpecifier', {
+                          local: u('Identifier', {name: 'MDXLayout'})
+                        })
+                      : create(
+                          specifier.local,
+                          u('ImportSpecifier', {
+                            imported: specifier.local,
+                            local: u('Identifier', {name: 'MDXLayout'})
+                          })
+                        )
+                  ],
+                  source: create(
+                    child.source,
+                    u('Literal', {value: child.source.value})
+                  )
+                })
+              )
+            )
+
+            return false
           }
-        }
-        // ```js
-        // export function a() {}
-        // export class A {}
-        // export const a = 1
-        // export {a, b as c}
-        // ```
-        else {
+
+          return true
+        })
+
+        // If there are other things imported, keep it.
+        if (child.specifiers.length > 0) {
           handleExport(child)
         }
       }
       // ```js
       // export * from 'a'
       // ```
-      else if (child.type === 'ExportAllDeclaration') {
+      else if (
+        child.type === 'ExportNamedDeclaration' ||
+        child.type === 'ExportAllDeclaration'
+      ) {
         handleExport(child)
       } else if (
         child.type === 'ImportNamespaceSpecifier' ||
         child.type === 'ImportDeclaration'
       ) {
-        handleImport(child)
+        handleEsm(child)
       } else if (
         child.type === 'ExpressionStatement' &&
         (child.expression.type === 'JSXFragment' ||
@@ -221,19 +211,31 @@ export function recmaDocument(options = {}) {
       replacement.push(createMdxContent())
     }
 
+    exportedIdentifiers.push(['MDXContent', 'default'])
+
     if (outputFormat === 'function-body') {
-      exportedIdentifiers.push(['MDXContent', 'default'])
       replacement.push(
         u('ReturnStatement', {
           argument: u('ObjectExpression', {
-            properties: exportedIdentifiers.map((d) => {
-              return u('Property', {
-                kind: 'init',
-                shorthand: typeof d === 'string',
-                key: u('Identifier', {name: typeof d === 'string' ? d : d[1]}),
-                value: u('Identifier', {name: typeof d === 'string' ? d : d[0]})
+            properties: [].concat(
+              Array.from({length: exportAllCount}).map((d, index) =>
+                u('SpreadElement', {
+                  argument: u('Identifier', {name: '_exportAll' + (index + 1)})
+                })
+              ),
+              exportedIdentifiers.map((d) => {
+                return u('Property', {
+                  kind: 'init',
+                  shorthand: typeof d === 'string',
+                  key: u('Identifier', {
+                    name: typeof d === 'string' ? d : d[1]
+                  }),
+                  value: u('Identifier', {
+                    name: typeof d === 'string' ? d : d[0]
+                  })
+                })
               })
-            })
+            )
           })
         })
       )
@@ -247,104 +249,131 @@ export function recmaDocument(options = {}) {
 
     tree.body = replacement
 
-    function handleImport(node) {
-      if (outputFormat === 'function-body') {
-        handleImportExportFrom(node)
-      } else {
-        replacement.push(node)
-      }
-    }
-
     function handleExport(node) {
       var child
 
-      if (outputFormat === 'function-body') {
-        // ```js
-        // export function a() {}
-        // export class A {}
-        // export const a = 1
-        // ```
-        if (node.declaration) {
-          replacement.push(node.declaration)
-
-          if (
-            node.declaration.type === 'FunctionDeclaration' ||
-            node.declaration.type === 'ClassDeclaration'
-          ) {
-            exportedIdentifiers.push(node.declaration.id.name)
-          }
-          // Must be a variable declaration: other things can’t be exported with
-          // ESM.
-          else {
-            for (child of node.declaration.declarations) {
-              exportedIdentifiers.push(child.id.name)
-            }
-          }
-        } else if (node.source) {
-          handleImportExportFrom(node)
-        }
-
-        // ```js
-        // export {a, b as c}
-        // export {a, b as c} from 'd'
-        // ```
-        if (node.specifiers) {
-          for (child of node.specifiers) {
-            exportedIdentifiers.push(
-              child.local.name === child.exported.name
-                ? child.local.name
-                : [child.local.name, child.exported.name]
-            )
+      // ```js
+      // export function a() {}
+      // export class A {}
+      // export const a = 1
+      // ```
+      if (node.declaration) {
+        if (
+          node.declaration.type === 'FunctionDeclaration' ||
+          node.declaration.type === 'ClassDeclaration'
+        ) {
+          exportedIdentifiers.push(node.declaration.id.name)
+        } else {
+          for (child of node.declaration.declarations) {
+            exportedIdentifiers.push(child.id.name)
           }
         }
-      } else {
-        replacement.push(node)
       }
+
+      // ```js
+      // export {a, b as c}
+      // export {a, b as c} from 'd'
+      // ```
+      if (node.specifiers) {
+        for (child of node.specifiers) {
+          exportedIdentifiers.push(child.exported.name)
+        }
+      }
+
+      handleEsm(node)
     }
 
-    function handleImportExportFrom(node) {
+    function handleEsm(node) {
       var value
+      var replace
+      var id
+      var declarations
 
-      if (!baseUrl) {
-        file.fail(
-          'Cannot use `import` or `export … from` in `evaluateSync` or `evaluate` w/o passing `baseUrl`: use `compile`, `compileSync`, or use `evaluate` and pass a `baseUrl`',
-          positionFromEstree(child),
-          'recma-document:contain-export'
-        )
-      }
+      // Rewrite the source of the `import` / `export … from`.
+      // See: <https://html.spec.whatwg.org/multipage/webappapis.html#resolve-a-module-specifier>
+      if (baseUrl && node.source) {
+        value = node.source.value
 
-      value = node.source.value
-
-      // Relative.
-      if (/^\.{0,2}\//.test(value)) {
-        value = new URL(value, baseUrl)
-      } else {
-        // Bare specifiers such as `some-package`, `@some-package`, and
-        // `some-package/path` will crash here.
-        // Full URLs pass.
         try {
+          // A full valid URL.
           value = new URL(value)
-        } catch {}
+        } catch {
+          // Relative: `/example.js`, `./example.js`, and `../example.js`.
+          if (/^\.{0,2}\//.test(value)) {
+            value = new URL(value, baseUrl)
+          }
+          // Otherwise, it’s a bare specifiers.
+          // For example `some-package`, `@some-package`, and
+          // `some-package/path`.
+          // These are supported in Node and browsers plan to support them
+          // with import maps (<https://github.com/WICG/import-maps>).
+        }
+
+        node.source = create(node.source, u('Literal', {value}))
       }
 
-      replacement.push(
-        u('VariableDeclaration', {
-          kind: 'const',
-          declarations: [
-            u('VariableDeclarator', {
-              id: specifiersToObjectPattern(node.specifiers),
-              init: u('AwaitExpression', {
-                argument: create(
-                  node,
-                  u('ImportExpression', {
-                    source: create(node.source, u('Literal', {value}))
-                  })
-                )
+      if (outputFormat === 'function-body') {
+        if (node.source) {
+          if (!useDynamicImport) {
+            file.fail(
+              'Cannot use `import` or `export … from` in `evaluate` (outputting a function body) by default: please set `useDynamicImport: true` (and probably specify a `baseUrl`)',
+              positionFromEstree(node),
+              'recma-document:invalid-esm-statement'
+            )
+          }
+
+          // ```
+          // import a from 'b'
+          // //=> const {default: a} = await import('b')
+          // export {a, b as c} from 'd'
+          // //=> const {a, c: b} = await import('d')
+          // export * from 'a'
+          // //=> const _exportAll0 = await import('a')
+          // ```
+          id = node.specifiers
+            ? specifiersToObjectPattern(node.specifiers)
+            : u('Identifier', {name: '_exportAll' + ++exportAllCount})
+
+          replace = u('VariableDeclaration', {
+            kind: 'const',
+            declarations: [
+              u('VariableDeclarator', {
+                id,
+                init: u('AwaitExpression', {
+                  argument: create(
+                    node,
+                    u('ImportExpression', {source: node.source})
+                  )
+                })
               })
-            })
-          ]
-        })
-      )
+            ]
+          })
+        } else if (node.declaration) {
+          replace = node.declaration
+        } else {
+          declarations = node.specifiers
+            .filter(
+              (specifier) => specifier.local.name !== specifier.exported.name
+            )
+            .map((specifier) =>
+              u('VariableDeclarator', {
+                id: specifier.exported,
+                init: specifier.local
+              })
+            )
+
+          if (declarations.length > 0) {
+            replace = u('VariableDeclaration', {kind: 'const', declarations})
+          }
+        }
+        // Empty
+      } else {
+        replace = node
+      }
+
+      if (replace) {
+        replacement.push(replace)
+      }
     }
   }
 

--- a/lib/util/estree-util-specifiers-to-object-pattern.js
+++ b/lib/util/estree-util-specifiers-to-object-pattern.js
@@ -19,15 +19,22 @@ export function specifiersToObjectPattern(specifiers) {
           : 'exported' in specifier
           ? specifier.exported
           : u('Identifier', {name: 'default'})
+      var value = specifier.local
+
+      if (specifier.type === 'ExportSpecifier') {
+        value = key
+        key = specifier.local
+      }
+
       return create(
         specifier,
         u('Property', {
           kind: 'init',
-          shorthand: key.name === specifier.local.name,
+          shorthand: key.name === value.name,
           method: false,
           computed: false,
           key,
-          value: specifier.local
+          value
         })
       )
     })

--- a/lib/util/resolve-evaluate-options.js
+++ b/lib/util/resolve-evaluate-options.js
@@ -9,10 +9,7 @@
  *
  * @typedef {Omit<ProcessorOptions, 'jsx' | 'jsxImportSource' | 'jsxRuntime' | 'pragma' | 'pragmaFrag' | 'pragmaImportSource' | 'providerImportSource' | 'outputFormat'> } EvaluateProcessorOptions
  *
- * @typedef ExtraOptions
- * @property {string} baseUrl URL to resolve imports from (typically: pass `import.meta.url`)
- *
- * @typedef {EvaluateProcessorOptions & RunnerOptions & ExtraOptions} EvaluateOptions
+ * @typedef {EvaluateProcessorOptions & RunnerOptions} EvaluateOptions
  */
 
 /**

--- a/test/context/data.js
+++ b/test/context/data.js
@@ -1,1 +1,3 @@
 export var number = 3.14
+
+export default 2 * number


### PR DESCRIPTION
[**View rendered readme**](https://github.com/wooorm/xdm/tree/use-dynamic-import#optionsoutputformat)

Split previously experimental into two stable options:

*   `useDynamicImport` — compile import statements into dynamic import expressions
*   `baseUrl` — resolve relative import specifiers from a given URL

This additionally fixes two bugs in the `'function-body'` output format:

*   `export * from 'a'` was not supported
*   `export {a as b}` was inverted

Closes GH-23.
Related-to GH-26.

/cc @lunelson