### PR TITLE
Add missing type definitions for source-map

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "@rollup/pluginutils": "^4.0.0",
     "@types/loader-utils": "^2.0.0",
+    "@types/source-map": "^0.5.7",
     "astring": "^1.6.0",
     "deasync": "^0.1.0",
     "estree-util-build-jsx": "^2.0.0",


### PR DESCRIPTION
In my project TypeScript fails in `recma-stringify.d.ts` for `import('source-map')` because the types don't exist for `source-map`.