### PR TITLE
Add `main` field to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,14 +20,6 @@
     "Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)"
   ],
   "main": "./index.js",
-  "exports": {
-    ".": "./index.js",
-    "./esbuild.js": "./esbuild.js",
-    "./rollup.js": "./rollup.js",
-    "./webpack.js": "./webpack.js",
-    "./esm-loader.js": "./esm-loader.js",
-    "./xdm-register.cjs": "./xdm-register.cjs"
-  },
   "type": "module",
   "types": "./index.d.ts",
   "sideEffects": false,

--- a/package.json
+++ b/package.json
@@ -19,6 +19,15 @@
   "contributors": [
     "Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)"
   ],
+  "main": "./index.js",
+  "exports": {
+    ".": "./index.js",
+    "./esbuild.js": "./esbuild.js",
+    "./rollup.js": "./rollup.js",
+    "./webpack.js": "./webpack.js",
+    "./esm-loader.js": "./esm-loader.js",
+    "./xdm-register.cjs": "./xdm-register.cjs"
+  },
   "type": "module",
   "types": "./index.d.ts",
   "sideEffects": false,

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "contributors": [
     "Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)"
   ],
-  "main": "./index.js",
+  "main": "index.js",
   "type": "module",
   "types": "./index.d.ts",
   "sideEffects": false,


### PR DESCRIPTION
Fixes https://github.com/wooorm/xdm/issues/49

I've checked the [package.json docs](https://nodejs.org/api/packages.html#packages_node_js_package_json_field_definitions) and looked at a few other libraries to see how they implemented `main` and `exports`. Locally I've replaced the `xdm` package and the error in my console was gone.

This is the first time for me using `main` and `exports` fields so some caution and extra checking is required :)