### PR TITLE
Add support for file contents from other esbuild plugins

### DIFF
--- a/lib/integration/esbuild.js
+++ b/lib/integration/esbuild.js
@@ -39,6 +39,7 @@ export function esbuild(options) {
    * @param {OnLoadArgs} data
    */
   async function onload(data) {
+    /** @type {string} */
     var doc =
       data.pluginData && data.pluginData.contents
         ? data.pluginData.contents

--- a/lib/integration/esbuild.js
+++ b/lib/integration/esbuild.js
@@ -36,7 +36,7 @@ export function esbuild(options) {
   }
 
   /**
-   * @param {OnLoadArgs} data
+   * @param {Omit.<OnLoadArgs, 'pluginData'> & {pluginData?: {contents?: string}}} data
    */
   async function onload(data) {
     /** @type {string} */

--- a/lib/integration/esbuild.js
+++ b/lib/integration/esbuild.js
@@ -39,7 +39,11 @@ export function esbuild(options) {
    * @param {OnLoadArgs} data
    */
   async function onload(data) {
-    var doc = String(await fs.readFile(data.path))
+    var doc =
+      data.pluginData && data.pluginData.contents
+        ? data.pluginData.contents
+        : String(await fs.readFile(data.path))
+
     var file = vfile({contents: doc, path: data.path})
     /** @type {VFileMessage[]} */
     var messages = []


### PR DESCRIPTION
As discussed in https://github.com/kentcdodds/mdx-bundler/pull/45 this allows the esbuild plugin to accept file contents either from the disk or from `pluginData.contents`. Our `inMemory` plugin will use this to pass mdx content over that doesn't exist on the disk.