### PR TITLE
Add docs for two new plugins

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1823,7 +1823,13 @@ But as the above example shows, it’s a useful place to put some extra fields.
 format of that meta string is, so it defaults to how markdown handles it: `meta`
 is ignored.
 
-But it’s possible to pass that string as a prop by writing a rehype plugin:
+[`remark-mdx-code-meta`](https://github.com/remarkjs/remark-mdx-code-meta) can
+be used to interpret code `meta` as JSX props syntax.
+
+It’s also possible to write a custom plugin to interpret the `meta` however you
+want.
+For example, it’s possible to pass that string as a prop by writing a rehype
+plugin:
 
 ```js
 function rehypeMetaAsAttribute() {
@@ -2087,6 +2093,10 @@ None yet!
 
 ###### Plugins
 
+*   [`rehype-mdx-title`](https://github.com/remcohaszing/rehype-mdx-title)
+    — expose the page title as a string
+*   [`remark-mdx-code-meta`](https://github.com/remcohaszing/remark-mdx-code-meta)
+    — interpret the code `meta` field as JSX props
 *   [`remark-mdx-images`](https://github.com/remcohaszing/remark-mdx-images)
     — change image sources to JavaScript imports
 *   [`remark-mdx-frontmatter`](https://github.com/remcohaszing/remark-mdx-frontmatter)

--- a/readme.md
+++ b/readme.md
@@ -1823,11 +1823,13 @@ But as the above example shows, it’s a useful place to put some extra fields.
 format of that meta string is, so it defaults to how markdown handles it: `meta`
 is ignored.
 
-[`remark-mdx-code-meta`](https://github.com/remarkjs/remark-mdx-code-meta) can
-be used to interpret code `meta` as JSX props syntax.
+The short answer is:
+use [`remark-mdx-code-meta`](https://github.com/remarkjs/remark-mdx-code-meta),
+it lets you type JSX attributes in the `meta` part and exposes them on the
+`pre` component.
 
-It’s also possible to write a custom plugin to interpret the `meta` however you
-want.
+Or you can do it yourself, however you want, by writing a custom plugin to
+interpret the `meta` field.
 For example, it’s possible to pass that string as a prop by writing a rehype
 plugin:
 


### PR DESCRIPTION
This adds `rehype-mdx-title` and `remark-mdx-code-meta` to the plugin list in the readme.

`remark-mdx-code-meta` is also added as an option for interpreting the code `meta` field.