### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug.md
+++ b/.github/ISSUE_TEMPLATE/1-bug.md
@@ -1,0 +1,41 @@
+---
+name: 🐛 Bug report
+about: Create a report to help us improve
+labels: bug
+---
+
+<!--
+Ouch, sorry you ran into a bug.  Thank for taking the time to report it!
+
+Please fill in as much of the template below as you’re able.
+-->
+
+### Subject of the issue
+
+Describe your issue here.
+
+### Your environment
+
+*   **OS**: <!-- Name and version of operating system -->
+*   **Packages**: <!-- Names and version of required packages -->
+*   **Env**: <!-- Version of node, npm, yarn, or names and versions of browser -->
+
+### Steps to reproduce
+
+Tell us how to reproduce this issue.  Please provide a working and simplified example.
+
+🎉 BONUS POINTS for creating a [minimal reproduction](https://stackoverflow.com/help/mcve) and uploading it to GitHub.  This will get you the fastest support.  🎉
+
+<!--
+Consider using a codesandbox or stackblitz to make the issue easy to replicate, here are some starters:
+https://codesandbox.io/s/xdm-create-react-app-starter-71mp9
+https://stackblitz.com/edit/xdm-create-react-app-starter
+--->
+
+### Expected behavior
+
+What should happen?
+
+### Actual behavior
+
+What happens instead?

--- a/.github/ISSUE_TEMPLATE/1-bug.md
+++ b/.github/ISSUE_TEMPLATE/1-bug.md
@@ -1,41 +1,64 @@
 ---
 name: 🐛 Bug report
 about: Create a report to help us improve
-labels: bug
+---
+
 ---
 
 <!--
-Ouch, sorry you ran into a bug.  Thank for taking the time to report it!
+  Please check the needed checkboxes ([ ] -> [x]) and fill out the TODOs.
+  Leave the comments as they are: they won’t show on GitHub.
 
-Please fill in as much of the template below as you’re able.
+  Some general tips:
+  - Is this really a problem?
+  - Is this a problem here?
+  - Can this be solved in a different way?
 -->
 
-### Subject of the issue
+### Initial checklist
 
-Describe your issue here.
+*   [ ] I read the support docs <!-- https://github.com/micromark/.github/blob/main/support.md -->
+*   [ ] I read the contributing guide <!-- https://github.com/micromark/.github/blob/main/contributing.md -->
+*   [ ] I agree to follow the code of conduct <!-- https://github.com/micromark/.github/blob/main/code-of-conduct.md -->
+*   [ ] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Amicromark&type=Issues -->
 
-### Your environment
+<!--
+  Please test using the latest version of the relevant packages to make sure
+  your issue has not already been fixed. Also make sure you’re on recent versions
+  of Node and npm.
+-->
 
-*   **OS**: <!-- Name and version of operating system -->
-*   **Packages**: <!-- Names and version of required packages -->
-*   **Env**: <!-- Version of node, npm, yarn, or names and versions of browser -->
+Affected packages and versions: TODO
 
 ### Steps to reproduce
 
-Tell us how to reproduce this issue.  Please provide a working and simplified example.
-
-🎉 BONUS POINTS for creating a [minimal reproduction](https://stackoverflow.com/help/mcve) and uploading it to GitHub.  This will get you the fastest support.  🎉
-
 <!--
-Consider using a codesandbox or stackblitz to make the issue easy to replicate, here are some starters:
-https://codesandbox.io/s/xdm-create-react-app-starter-71mp9
-https://stackblitz.com/edit/xdm-create-react-app-starter
---->
+  How did this happen?
+  Please provide a minimal, reproducible example:
+  https://stackoverflow.com/help/minimal-reproducible-example
+  Issues without reproduction steps or code examples may be immediately closed
+  as not actionable.
+
+  Here is a starter codesandbox: https://codesandbox.io/s/xdm-create-react-app-starter-71mp9
+
+  Either link to runnable code (not your whole repo) or post the code inline.
+-->
+
+1.  TODO
+2.  TODO
+
+Link to code example: TODO
 
 ### Expected behavior
 
-What should happen?
+<!--What should happen?-->
+
+TODO
 
 ### Actual behavior
 
-What happens instead?
+<!--What happens instead?-->
+
+TODO
+
+<!--do not edit: bug-->

--- a/.github/ISSUE_TEMPLATE/1-bug.md
+++ b/.github/ISSUE_TEMPLATE/1-bug.md
@@ -20,7 +20,7 @@ about: Create a report to help us improve
 *   [ ] I read the support docs <!-- https://github.com/micromark/.github/blob/main/support.md -->
 *   [ ] I read the contributing guide <!-- https://github.com/micromark/.github/blob/main/contributing.md -->
 *   [ ] I agree to follow the code of conduct <!-- https://github.com/micromark/.github/blob/main/code-of-conduct.md -->
-*   [ ] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Amicromark&type=Issues -->
+*   [ ] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=repo%3Awooorm%2Fxdm&type=Issues -->
 
 <!--
   Please test using the latest version of the relevant packages to make sure

--- a/.github/ISSUE_TEMPLATE/2-feature.md
+++ b/.github/ISSUE_TEMPLATE/2-feature.md
@@ -1,27 +1,48 @@
 ---
 name: 🚀 Feature request
-about: Suggest an idea for this project
-labels: enhancement
+about: Suggest an idea
 ---
 
 <!--
-Thank you for suggesting an idea to make this project better!
-
-Please fill in as much of the template below as you’re able.
+  Please check the needed checkboxes ([ ] -> [x]) and fill out the TODOs.
+  Leave the comments as they are: they won’t show on GitHub.
 -->
 
-### Subject of the feature
+### Initial checklist
 
-Describe your issue here.
+*   [ ] I read the support docs <!-- https://github.com/micromark/.github/blob/main/support.md -->
+*   [ ] I read the contributing guide <!-- https://github.com/micromark/.github/blob/main/contributing.md -->
+*   [ ] I agree to follow the code of conduct <!-- https://github.com/micromark/.github/blob/main/code-of-conduct.md -->
+*   [ ] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Amicromark&type=Issues -->
+
+### Subject
+
+<!--
+  Describe your issue here.
+
+  Some general tips:
+  - Is this really a problem?
+  - Is this a problem here?
+-->
+
+TODO
 
 ### Problem
 
-If the feature requests relates to a problem, please describe the problem you are trying to solve here.
+<!-- Please describe the problem you are trying to solve here. -->
 
-### Expected behavior
+TODO
 
-What should happen?  Please describe the desired behavior.
+### Solution
+
+<!-- What should happen? Please describe the desired behavior. -->
+
+TODO
 
 ### Alternatives
 
-What are the alternative solutions?  Please describe what else you have considered?
+<!-- What are the alternative solutions? Can this be solved in a different way? -->
+
+TODO
+
+<!--do not edit: feat-->

--- a/.github/ISSUE_TEMPLATE/2-feature.md
+++ b/.github/ISSUE_TEMPLATE/2-feature.md
@@ -13,7 +13,7 @@ about: Suggest an idea
 *   [ ] I read the support docs <!-- https://github.com/micromark/.github/blob/main/support.md -->
 *   [ ] I read the contributing guide <!-- https://github.com/micromark/.github/blob/main/contributing.md -->
 *   [ ] I agree to follow the code of conduct <!-- https://github.com/micromark/.github/blob/main/code-of-conduct.md -->
-*   [ ] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Amicromark&type=Issues -->
+*   [ ] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=repo%3Awooorm%2Fxdm&type=Issues -->
 
 ### Subject
 

--- a/.github/ISSUE_TEMPLATE/2-feature.md
+++ b/.github/ISSUE_TEMPLATE/2-feature.md
@@ -1,0 +1,27 @@
+---
+name: 🚀 Feature request
+about: Suggest an idea for this project
+labels: enhancement
+---
+
+<!--
+Thank you for suggesting an idea to make this project better!
+
+Please fill in as much of the template below as you’re able.
+-->
+
+### Subject of the feature
+
+Describe your issue here.
+
+### Problem
+
+If the feature requests relates to a problem, please describe the problem you are trying to solve here.
+
+### Expected behavior
+
+What should happen?  Please describe the desired behavior.
+
+### Alternatives
+
+What are the alternative solutions?  Please describe what else you have considered?

--- a/.github/ISSUE_TEMPLATE/3-question.md
+++ b/.github/ISSUE_TEMPLATE/3-question.md
@@ -1,7 +1,6 @@
 ---
 name: 🙋 Question
 about: Ask a question about the project
-labels: question
 ---
 
 <!--
@@ -24,6 +23,6 @@ Spending the extra time up front can help save everyone time in the long run.
 *   Learn about the [rubber duck debugging method](https://rubberduckdebugging.com)
 *   Avoid falling for the [XY problem](https://meta.stackexchange.com/questions/66377/what-is-the-xy-problem/66378#66378)
 *   Search on GitHub to see if a similar question has been asked
-*   If possible, provide sample code, a [CodeSandbox][], or a video
+*   If possible, provide sample code, a [CodeSandbox](https://codesandbox.io/s/xdm-create-react-app-starter-71mp9), or a video
 *   The more time you put into asking your question, the better we can help you
 -->

--- a/.github/ISSUE_TEMPLATE/3-question.md
+++ b/.github/ISSUE_TEMPLATE/3-question.md
@@ -1,0 +1,29 @@
+---
+name: 🙋 Question
+about: Ask a question about the project
+labels: question
+---
+
+<!--
+Help us help you!
+
+Spending time framing a question and adding support links or resources makes it
+much easier for us to help.
+It’s easy to fall into the trap of asking something too specific when you’re
+close to a problem.
+Then, those trying to help you out have to spend a lot of time asking additional
+questions to understand what you are hoping to achieve.
+
+Spending the extra time up front can help save everyone time in the long run.
+
+*   Try to define what you need help with:
+    *   Is there something in particular you want to do?
+    *   What problem are you encountering and what steps have you taken to try
+        and fix it?
+    *   Is there a concept you’re not understanding?
+*   Learn about the [rubber duck debugging method](https://rubberduckdebugging.com)
+*   Avoid falling for the [XY problem](https://meta.stackexchange.com/questions/66377/what-is-the-xy-problem/66378#66378)
+*   Search on GitHub to see if a similar question has been asked
+*   If possible, provide sample code, a [CodeSandbox][], or a video
+*   The more time you put into asking your question, the better we can help you
+-->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
based off https://github.com/remarkjs/.github/tree/c669bbe44cd9ed1960e36c5fb172f4d03f7911c2/.github/ISSUE_TEMPLATE

* replaces references to remark with xdm.
* removes links to github discussions since they aren't enabled on this repo, and instead adds a question template
* Adds potential starts for codesandbox and stackblitz (these appear to be not fully functional due to ESM support gaps in these platforms, alternative ideas are welcome)