### PR TITLE
esbuild: fix empty string for `pluginData.contents`

### DIFF
--- a/lib/integration/esbuild.js
+++ b/lib/integration/esbuild.js
@@ -41,7 +41,7 @@ export function esbuild(options) {
   async function onload(data) {
     /** @type {string} */
     const doc =
-      data.pluginData && data.pluginData.contents
+      data.pluginData && data.pluginData.contents !== undefined
         ? data.pluginData.contents
         : String(await fs.readFile(data.path))
 


### PR DESCRIPTION
This is a minor bug fix for something that was reported to me by a mdx-bundler user.

Passing an empty string through the `pluginData.contents` system is falsey which causes the plugin to fallback on reading the file directly. This of course throws an error for us as the file path doesn't exist.

This solution checks if its not undefined instead of it being truthy.