### PR TITLE
Fix WMR docs link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1371,7 +1371,7 @@ your `vite.config.js`.
 #### WMR
 
 [WMR](https://github.com/preactjs/wmr) supports [Rollup][] plugins directly by
-[pushing them to `config.plugins`](https://github.com/preactjs/wmr#configuration-and-plugins)
+[pushing them to `config.plugins`](https://github.com/preactjs/wmr/tree/main/packages/wmr#configuration-and-plugins)
 in `wmr.config.js`.
 
 ### Compilers


### PR DESCRIPTION
We migrated to a more typical mono-repo setup at some point, and with that cleaned up the top-level ReadMe quite a bit.