### PR TITLE
Add experimental remote MDX support to esbuild

### DIFF
--- a/lib/integration/esbuild.js
+++ b/lib/integration/esbuild.js
@@ -35,7 +35,7 @@ const p = process
 export function esbuild(options = {}) {
   const {allowDangerousRemoteMdx, ...rest} = options
   const name = 'esbuild-xdm'
-  const remoteNs = name + '-remote'
+  const remoteNamespace = name + '-remote'
   const {extnames, process} = createFormatAwareProcessors(rest)
 
   return {name, setup}
@@ -60,17 +60,17 @@ export function esbuild(options = {}) {
       )
 
       build.onResolve(
-        {filter: filterHttpOrRelative, namespace: remoteNs},
+        {filter: filterHttpOrRelative, namespace: remoteNamespace},
         resolveInRemote
       )
     }
 
-    build.onLoad({filter: /.*/, namespace: remoteNs}, onloadremote)
+    build.onLoad({filter: /.*/, namespace: remoteNamespace}, onloadremote)
     build.onLoad({filter}, onload)
 
     /** @param {OnResolveArgs} args  */
     function resolveRemoteInLocal(args) {
-      return {path: args.path, namespace: remoteNs}
+      return {path: args.path, namespace: remoteNamespace}
     }
 
     // Intercept all import paths inside downloaded files and resolve them against
@@ -82,7 +82,7 @@ export function esbuild(options = {}) {
     function resolveInRemote(args) {
       return {
         path: String(new URL(args.path, args.importer)),
-        namespace: remoteNs
+        namespace: remoteNamespace
       }
     }
 
@@ -92,7 +92,7 @@ export function esbuild(options = {}) {
      */
     async function onloadremote(data) {
       const href = data.path
-      console.log('%s: downloading `%s`', remoteNs, href)
+      console.log('%s: downloading `%s`', remoteNamespace, href)
       const contents = (await got(href, {cache})).body
 
       return filter.test(href)

--- a/lib/integration/esbuild.js
+++ b/lib/integration/esbuild.js
@@ -102,7 +102,9 @@ export function esbuild(options = {}) {
             namespace: 'file',
             pluginData: {contents}
           })
-        : {contents, loader: 'js', resolveDir: p.cwd()}
+        : // V8 on Erbium.
+          /* c8 ignore next 2 */
+          {contents, loader: 'js', resolveDir: p.cwd()}
     }
 
     /**

--- a/lib/integration/esbuild.js
+++ b/lib/integration/esbuild.js
@@ -2,29 +2,41 @@
  * @typedef {import('esbuild').Plugin} Plugin
  * @typedef {import('esbuild').PluginBuild} PluginBuild
  * @typedef {import('esbuild').OnLoadArgs} OnLoadArgs
+ * @typedef {import('esbuild').OnLoadResult} OnLoadResult
+ * @typedef {import('esbuild').OnResolveArgs} OnResolveArgs
  * @typedef {import('esbuild').Message} Message
  * @typedef {import('vfile').VFileContents} VFileContents
  * @typedef {import('vfile-message').VFileMessage} VFileMessage
  * @typedef {import('unist').Point} Point
  * @typedef {import('../core.js').ProcessorOptions} ProcessorOptions
+ *
+ * @typedef {ProcessorOptions & {allowDangerousRemoteMdx?: boolean}} Options
  */
 
 import {promises as fs} from 'fs'
+import got from 'got'
 import vfile from 'vfile'
 import {createFormatAwareProcessors} from '../util/create-format-aware-processors.js'
 import {extnamesToRegex} from '../util/extnames-to-regex.js'
 
 const eol = /\r\n|\r|\n|\u2028|\u2029/g
 
+/** @type Map<string, string> */
+const cache = new Map()
+
+const p = process
+
 /**
  * Compile MDX w/ esbuild.
  *
- * @param {ProcessorOptions} [options]
+ * @param {Options} [options]
  * @return {Plugin}
  */
-export function esbuild(options) {
+export function esbuild(options = {}) {
+  const {allowDangerousRemoteMdx, ...rest} = options
   const name = 'esbuild-xdm'
-  const {extnames, process} = createFormatAwareProcessors(options)
+  const remoteNs = name + '-remote'
+  const {extnames, process} = createFormatAwareProcessors(rest)
 
   return {name, setup}
 
@@ -32,97 +44,162 @@ export function esbuild(options) {
    * @param {PluginBuild} build
    */
   function setup(build) {
-    build.onLoad({filter: extnamesToRegex(extnames)}, onload)
-  }
+    const filter = extnamesToRegex(extnames)
+    /* eslint-disable-next-line security/detect-non-literal-regexp */
+    const filterHttp = new RegExp('^https?:\\/{2}.+' + filter.source)
+    const filterHttpOrRelative = /^(https?:\/{2}|.{1,2}\/).*/
 
-  /**
-   * @param {Omit.<OnLoadArgs, 'pluginData'> & {pluginData?: {contents?: string}}} data
-   */
-  async function onload(data) {
-    /** @type {string} */
-    const doc =
-      data.pluginData && data.pluginData.contents !== undefined
-        ? data.pluginData.contents
-        : String(await fs.readFile(data.path))
+    if (allowDangerousRemoteMdx) {
+      // Intercept import paths starting with "http:" and "https:" so
+      // esbuild doesn't attempt to map them to a file system location.
+      // Tag them with the "http-url" namespace to associate them with
+      // this plugin.
+      build.onResolve(
+        {filter: filterHttp, namespace: 'file'},
+        resolveRemoteInLocal
+      )
 
-    let file = vfile({contents: doc, path: data.path})
-    /** @type {VFileMessage[]} */
-    let messages = []
-    /** @type {Message[]} */
-    const errors = []
-    /** @type {Message[]} */
-    const warnings = []
-    /** @type {VFileContents} */
-    let contents
-    /** @type {VFileMessage} */
-    let message
-    /** @type {Point} */
-    let start
-    /** @type {Point} */
-    let end
-    /** @type {number} */
-    let length
-    /** @type {number} */
-    let lineStart
-    /** @type {number} */
-    let lineEnd
-    /** @type {RegExpExecArray} */
-    let match
-    /** @type {number} */
-    let line
-    /** @type {number} */
-    let column
-
-    try {
-      file = await process(file)
-      contents = file.contents
-      messages = file.messages
-    } catch (error) {
-      error.fatal = true
-      messages.push(error)
+      build.onResolve(
+        {filter: filterHttpOrRelative, namespace: remoteNs},
+        resolveInRemote
+      )
     }
 
-    for (message of messages) {
-      start = message.location.start
-      end = message.location.end
-      length = 0
-      lineStart = 0
-      line = undefined
-      column = undefined
+    build.onLoad({filter: /.*/, namespace: remoteNs}, onloadremote)
+    build.onLoad({filter}, onload)
 
-      if (start.line != null && start.column != null && start.offset != null) {
-        line = start.line
-        column = start.column - 1
-        lineStart = start.offset - column
-        length = 1
+    /** @param {OnResolveArgs} args  */
+    function resolveRemoteInLocal(args) {
+      return {path: args.path, namespace: remoteNs}
+    }
 
-        if (end.line != null && end.column != null && end.offset != null) {
-          length = end.offset - start.offset
-        }
+    // Intercept all import paths inside downloaded files and resolve them against
+    // the original URL. All of these
+    // files will be in the "http-url" namespace. Make sure to keep
+    // the newly resolved URL in the "http-url" namespace so imports
+    // inside it will also be resolved as URLs recursively.
+    /** @param {OnResolveArgs} args  */
+    function resolveInRemote(args) {
+      return {
+        path: String(new URL(args.path, args.importer)),
+        namespace: remoteNs
+      }
+    }
+
+    /**
+     * @param {OnLoadArgs} data
+     * @returns {Promise<OnLoadResult>}
+     */
+    async function onloadremote(data) {
+      const href = data.path
+      console.log('%s: downloading `%s`', remoteNs, href)
+      const contents = (await got(href, {cache})).body
+
+      return filter.test(href)
+        ? onload({
+            // Clean search and hash from URL.
+            path: Object.assign(new URL(href), {search: '', hash: ''}).href,
+            namespace: 'file',
+            pluginData: {contents}
+          })
+        : {contents, loader: 'js', resolveDir: p.cwd()}
+    }
+
+    /**
+     * @param {Omit.<OnLoadArgs, 'pluginData'> & {pluginData?: {contents?: string|Uint8Array}}} data
+     * @returns {Promise<OnLoadResult>}
+     */
+    async function onload(data) {
+      /** @type {string} */
+      const doc = String(
+        data.pluginData && data.pluginData.contents !== undefined
+          ? data.pluginData.contents
+          : await fs.readFile(data.path)
+      )
+
+      let file = vfile({contents: doc, path: data.path})
+      /** @type {VFileMessage[]} */
+      let messages = []
+      /** @type {Message[]} */
+      const errors = []
+      /** @type {Message[]} */
+      const warnings = []
+      /** @type {VFileContents} */
+      let contents
+      /** @type {VFileMessage} */
+      let message
+      /** @type {Point} */
+      let start
+      /** @type {Point} */
+      let end
+      /** @type {number} */
+      let length
+      /** @type {number} */
+      let lineStart
+      /** @type {number} */
+      let lineEnd
+      /** @type {RegExpExecArray} */
+      let match
+      /** @type {number} */
+      let line
+      /** @type {number} */
+      let column
+
+      try {
+        file = await process(file)
+        contents = file.contents
+        messages = file.messages
+      } catch (error) {
+        error.fatal = true
+        messages.push(error)
       }
 
-      eol.lastIndex = lineStart
-      match = eol.exec(doc)
-      lineEnd = match ? match.index : doc.length
-      ;(message.fatal ? errors : warnings).push({
-        pluginName: name,
-        text: message.reason,
-        notes: [],
-        location: {
-          namespace: 'file',
-          suggestion: '',
-          file: data.path,
-          line,
-          column,
-          length: Math.min(length, lineEnd),
-          lineText: doc.slice(lineStart, lineEnd)
-        },
-        detail: message
-      })
-    }
+      for (message of messages) {
+        start = message.location.start
+        end = message.location.end
+        length = 0
+        lineStart = 0
+        line = undefined
+        column = undefined
 
-    // V8 on Erbium.
-    /* c8 ignore next 2 */
-    return {contents, errors, warnings}
+        if (
+          start.line != null &&
+          start.column != null &&
+          start.offset != null
+        ) {
+          line = start.line
+          column = start.column - 1
+          lineStart = start.offset - column
+          length = 1
+
+          if (end.line != null && end.column != null && end.offset != null) {
+            length = end.offset - start.offset
+          }
+        }
+
+        eol.lastIndex = lineStart
+        match = eol.exec(doc)
+        lineEnd = match ? match.index : doc.length
+        ;(message.fatal ? errors : warnings).push({
+          pluginName: name,
+          text: message.reason,
+          notes: [],
+          location: {
+            namespace: 'file',
+            suggestion: '',
+            file: data.path,
+            line,
+            column,
+            length: Math.min(length, lineEnd),
+            lineText: doc.slice(lineStart, lineEnd)
+          },
+          detail: message
+        })
+      }
+
+      // V8 on Erbium.
+      /* c8 ignore next 2 */
+      return {contents, errors, warnings, resolveDir: p.cwd()}
+    }
   }
 }

--- a/lib/plugin/remark-mark-and-unravel.js
+++ b/lib/plugin/remark-mark-and-unravel.js
@@ -37,19 +37,28 @@ function onvisit(node, index, parent) {
   /** @type {Array.<Node>} */
   let children
 
-  if (parent && node.type === 'paragraph' && Array.isArray(node.children)) {
+  if (
+    parent &&
+    node.type === 'paragraph' &&
+    // @ts-expect-error: hush.
+    Array.isArray(node.children)
+  ) {
+    // @ts-expect-error: hush.
     // type-coverage:ignore-next-line
     children = node.children
 
     while (++offset < children.length) {
+      const child = children[offset]
+
       if (
-        children[offset].type === 'mdxJsxTextElement' ||
-        children[offset].type === 'mdxTextExpression'
+        child.type === 'mdxJsxTextElement' ||
+        child.type === 'mdxTextExpression'
       ) {
         oneOrMore = true
       } else if (
-        children[offset].type === 'text' &&
-        /^[\t\r\n ]+$/.test(String(children[offset].value))
+        child.type === 'text' &&
+        // @ts-expect-error: hush.
+        /^[\t\r\n ]+$/.test(String(child.value))
       ) {
         // Empty.
       } else {

--- a/lib/util/extnames-to-regex.js
+++ b/lib/util/extnames-to-regex.js
@@ -6,5 +6,7 @@
  */
 export function extnamesToRegex(extnames) {
   // eslint-disable-next-line security/detect-non-literal-regexp
-  return new RegExp('\\.(' + extnames.map((d) => d.slice(1)).join('|') + ')$')
+  return new RegExp(
+    '\\.(' + extnames.map((d) => d.slice(1)).join('|') + ')([?#]|$)'
+  )
 }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "estree-util-build-jsx": "^2.0.0",
     "estree-util-is-identifier-name": "^2.0.0",
     "estree-walker": "^3.0.0",
+    "got": "^11.0.0",
     "hast-util-to-estree": "^2.0.0",
     "loader-utils": "^2.0.0",
     "markdown-extensions": "^1.0.0",

--- a/readme.md
+++ b/readme.md
@@ -51,6 +51,7 @@ Node 12+ is needed to use it and it must be `import`ed instead of `require`d.
 *   [👩‍🔬 Lab](#-lab)
     *   [Importing `.mdx` files directly](#importing-mdx-files-directly)
     *   [Requiring `.mdx` files directly](#requiring-mdx-files-directly)
+    *   [Importing `.md` and `.mdx` files from the web in esbuild](#importing-md-and-mdx-files-from-the-web-in-esbuild)
 *   [MDX syntax](#mdx-syntax)
     *   [Markdown](#markdown)
     *   [JSX](#jsx)
@@ -952,6 +953,46 @@ The register hook uses [`evaluateSync`][eval].
 That means `import` (and `export … from`) are not supported when requiring
 `.mdx` files.
 
+### Importing `.md` and `.mdx` files from the web in esbuild
+
+When passing `allowDangerousRemoteMdx` to the esbuild loader, MD(X) and JS files
+can be imported from `http:` and `https:` urls.
+Take this `index.mdx` file:
+
+```jsx
+import Readme from 'https://raw.githubusercontent.com/wooorm/xdm/main/readme.md'
+
+Embed the xdm readme like so:
+
+<Readme />
+```
+
+And a module `build.js`:
+
+```js
+import xdm from 'xdm/esbuild.js'
+import esbuild from 'esbuild'
+
+await esbuild.build({
+  entryPoints: ['index.mdx'],
+  outfile: 'output.js',
+  format: 'esm',
+  plugins: [xdm({allowDangerousRemoteMdx: true, /* Other options… */})]
+})
+```
+
+Running that (`node build.js`) and evaluating `output.js` (depends on how you
+evaluate React stuff) would give:
+
+```jsx
+<p>Embed the xdm readme like so:</p>
+<h1>xdm</h1>
+// …
+<p><a href="https://github.com/wooorm/xdm/blob/main/license">MIT</a> © …</p>
+```
+
+> ⚠️ Note that this evaluates any JavaScript and MDX found over the wire!
+
 ## MDX syntax
 
 > **Note**!
@@ -1252,6 +1293,17 @@ esbuild takes care of turning modern JavaScript features into syntax that works
 wherever you want it to.
 No Babel needed.
 See esbuild’s docs for more info.
+
+`options` are the same as from [`compile`][compile] with the addition of:
+
+###### `options.allowDangerousRemoteMdx`
+
+Whether to allow importing from `http:` and `https:` URLs (`boolean`, default:
+`false`).
+See [§ Importing `.md` and `.mdx` files from the web in
+esbuild][import-from-web].
+
+> ⚠️ Note that this evaluates any JavaScript and MDX found over the wire!
 
 #### Rollup
 
@@ -2157,6 +2209,7 @@ None yet!
 
 *   Add support for `import Content from './file.mdx'` in Node
 *   Add support for `require('./file.mdx')` in Node
+*   Add support `allowDangerousRemoteMdx` in esbuild to load MD(X) from the web
 
 ## Architecture
 
@@ -2352,3 +2405,5 @@ Most of the work is done by:
 [pico]: https://github.com/micromatch/picomatch#globbing-features
 
 [lab]: #-lab
+
+[import-from-web]: #importing-md-and-mdx-files-from-the-web-in-esbuild

--- a/readme.md
+++ b/readme.md
@@ -955,6 +955,10 @@ That means `import` (and `export … from`) are not supported when requiring
 
 ### Importing `.md` and `.mdx` files from the web in esbuild
 
+> ⚠️ Note that this includes remote code in your bundle.
+> Make sure you trust it!
+> See [§ Security][security] for more info.
+
 When passing `allowDangerousRemoteMdx` to the esbuild loader, MD(X) and JS files
 can be imported from `http:` and `https:` urls.
 Take this `index.mdx` file:
@@ -987,11 +991,9 @@ evaluate React stuff) would give:
 ```jsx
 <p>Embed the xdm readme like so:</p>
 <h1>xdm</h1>
-// …
+{/* … */}
 <p><a href="https://github.com/wooorm/xdm/blob/main/license">MIT</a> © …</p>
 ```
-
-> ⚠️ Note that this evaluates any JavaScript and MDX found over the wire!
 
 ## MDX syntax
 
@@ -2407,3 +2409,5 @@ Most of the work is done by:
 [lab]: #-lab
 
 [import-from-web]: #importing-md-and-mdx-files-from-the-web-in-esbuild
+
+[security]: #security

--- a/test/core.js
+++ b/test/core.js
@@ -272,6 +272,8 @@ test('xdm', async (t) => {
     'should *not* support overwriting components in exports'
   )
 
+  console.log('\nnote: the next warning is expected!\n')
+
   try {
     renderToStaticMarkup(
       React.createElement(
@@ -428,6 +430,8 @@ test('xdm', async (t) => {
     )
   }
 
+  console.log('\nnote: the next warning is expected!\n')
+
   try {
     renderToStaticMarkup(React.createElement(await run(compileSync('<X />'))))
     t.fail()
@@ -472,6 +476,8 @@ test('xdm', async (t) => {
     '<p><i>z</i></p>',
     'should support setting components through context with a `providerImportSource`'
   )
+
+  console.log('\nnote: the next warning is expected!\n')
 
   try {
     renderToStaticMarkup(

--- a/test/files/md-file.md
+++ b/test/files/md-file.md
@@ -1,0 +1,1 @@
+Some content.

--- a/test/files/mdx-file-importing-markdown.mdx
+++ b/test/files/mdx-file-importing-markdown.mdx
@@ -1,0 +1,8 @@
+import {Pill} from '../context/components.js'
+import Content from './md-file.md'
+
+# heading
+
+A <Pill>little pill</Pill>.
+
+<Content />


### PR DESCRIPTION
This adds support for loading MD(X) files over the wire (`https?://`). This might be interesting for folks who have files in other repos for example. Or that want to include some readme from GitHub and such.
    
Note though that this is a) unsafe: it evals remote code, and b) experimental: Please test it out, see whether this is a good idea or not, and leave feedback!

*[Review w/o whitespace](https://github.com/wooorm/xdm/pull/66/files?w=1)*

*[See docs](https://github.com/wooorm/xdm/blob/remote-mdx/readme.md#importing-md-and-mdx-files-from-the-web-in-esbuild)*