### PR TITLE
Remove unused dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   "dependencies": {
     "@rollup/pluginutils": "^4.0.0",
     "@types/estree-jsx": "^0.0.1",
-    "@types/loader-utils": "^2.0.0",
     "astring": "^1.6.0",
     "estree-util-build-jsx": "^2.0.0",
     "estree-util-is-identifier-name": "^2.0.0",
@@ -68,6 +67,7 @@
     "@mdx-js/react": "2.0.0-next.8",
     "@theme-ui/preset-base": "^0.10.0",
     "@types/babel__core": "^7.0.0",
+    "@types/loader-utils": "^2.0.0",
     "@types/node": "^16.0.0",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",


### PR DESCRIPTION
It’s unused in the build output, meaning they can be safely moved into `devDependencies`.

This removes 7 indirect dependencies.