### PR TITLE
Fix note in Preact needing `className`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -108,7 +108,7 @@ See?
 Most of markdown works!
 Those XML-like things are not HTML though: they’re JSX.
 Note that there are some differences in how JSX should be authored: for example,
-React and Preact expect `className`, whereas Vue expects `class`.
+React expects `className`, whereas Vue expects `class`.
 See [§ MDX syntax][mdx-syntax] below for more on how the format works.
 
 ## Use


### PR DESCRIPTION
This comment that Preact expects `className` isn't true, nor has it ever been.

[Preact works with both `class` and `className`](https://preactjs.com/guide/v10/differences-to-react#main-differences) with no functional difference between them. While we prefer that users use `class`, as that better follows the DOM spec, it's just our preference.