### PR TITLE
Fix Next by using default import for CJS

### DIFF
--- a/lib/plugin/remark-mdx.js
+++ b/lib/plugin/remark-mdx.js
@@ -11,8 +11,9 @@
  */
 
 import syntaxMdxjs from 'micromark-extension-mdxjs'
-import pkg from 'mdast-util-mdx';
-const {fromMarkdown, toMarkdown} = pkg;
+import mdx from 'mdast-util-mdx'
+
+const {fromMarkdown, toMarkdown} = mdx
 
 /**
  * Add the micromark and mdast extensions for MDX.js (JS aware MDX).

--- a/lib/plugin/remark-mdx.js
+++ b/lib/plugin/remark-mdx.js
@@ -11,7 +11,8 @@
  */
 
 import syntaxMdxjs from 'micromark-extension-mdxjs'
-import {fromMarkdown, toMarkdown} from 'mdast-util-mdx'
+import pkg from 'mdast-util-mdx';
+const {fromMarkdown, toMarkdown} = pkg;
 
 /**
  * Add the micromark and mdast extensions for MDX.js (JS aware MDX).


### PR DESCRIPTION
Using named imports was rendering an error when using with Next.js and mdx-bundler, the following change fixes the problem