### PR TITLE
Add `--legacy-peer-deps` to `.npmrc`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: dcodeIO/setup-node-nvm@master
         with:
           node-version: ${{matrix.node}}
-      - run: npm install --legacy-peer-deps
+      - run: npm install
       - run: npm test
       - uses: codecov/codecov-action@v1
     strategy:

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
+legacy-peer-deps=true
 package-lock=false


### PR DESCRIPTION
npm is having issues resolving peer dependencies. This is a warning using legacy peer deps, but an error when using the new peer dependency behaviour in npm 7.

This is a local development issue only.