### PR TITLE
Fix `Layout` example component

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1256,7 +1256,9 @@ Layouts are components that wrap the whole content.
 They can be defined from within MDX using a default export:
 
 ```js
-export default function Layout({children}) => <main>{children}</main>
+export default function Layout({ children }) {
+  return <main>{children}</main>;
+}
 
 All the things.
 ```


### PR DESCRIPTION
Example used both expression and declaration. README is fairly long so I copy pasted it here. It was this:
```js
export default function Layout({children}) => <main>{children}</main>

All the things.
```
---
Considered 3 options: 
Named function declaration. Verbose but descriptive. (Proposing this one)
```js
export default function Layout({ children }) {
  return <main>{children}</main>;
}
```

Anonymous arrow function expression. Short but vague, what's the default export used again?
```js
export default ({ children }) => <main>{children}</main>;
```

Named arrow function expression. Looks weird, export to export?
```js
export const Layout = ({ children }) => <main>{children}</main>;
export default Layout;
```