### PR TITLE
Fix expectation of `props` being passed to components

### DIFF
--- a/lib/plugin/recma-jsx-rewrite.js
+++ b/lib/plugin/recma-jsx-rewrite.js
@@ -1,4 +1,5 @@
 /**
+ * @typedef {import('estree-jsx').Node} Node
  * @typedef {import('estree-jsx').Expression} Expression
  * @typedef {import('estree-jsx').Function} ESFunction
  * @typedef {import('estree-jsx').ImportSpecifier} ImportSpecifier
@@ -14,6 +15,8 @@
  *
  * @typedef {import('estree-walker').SyncHandler} WalkHandler
  *
+ * @typedef {import('periscopic').Scope & {node: Node}} Scope
+ *
  * @typedef RecmaJsxRewriteOptions
  * @property {'program'|'function-body'} [outputFormat='program'] Whether to use an import statement or `arguments[0]` to get the provider
  * @property {string} [providerImportSource] Place to import a provider from
@@ -22,6 +25,7 @@
  * @property {Array.<string>} objects
  * @property {Array.<string>} components
  * @property {Array.<string>} tags
+ * @property {ESFunction} node
  */
 
 import {name as isIdentifierName} from 'estree-util-is-identifier-name'
@@ -43,40 +47,57 @@ export function recmaJsxRewrite(options = {}) {
 
   return (tree) => {
     // Find everything that’s defined in the top-level scope.
-    const topScope = analyze(tree).scope.declarations
+    const scopeInfo = analyze(tree)
     /** @type {Array.<StackEntry>} */
-    const stack = []
+    const fnStack = []
     /** @type {boolean|undefined} */
     let importProvider
+    /** @type {Scope|null} */
+    let currentScope
 
     walk(tree, {
-      enter(node) {
+      enter(_node) {
+        const node = /** @type {Node} */ (_node)
+
         if (
           node.type === 'FunctionDeclaration' ||
           node.type === 'FunctionExpression' ||
           node.type === 'ArrowFunctionExpression'
         ) {
-          stack.push({objects: [], components: [], tags: []})
+          fnStack.push({objects: [], components: [], tags: [], node})
         }
 
-        if (node.type === 'JSXElement' && stack.length > 0) {
-          const element = /** @type {JSXElement} */ (node)
-          // Note: inject into the *top-level* function that contains JSX.
-          // Yes: we collect info about the stack, but we assume top-level functions
-          // are components.
-          const scope = stack[0]
-          let name = element.openingElement.name
+        const fnScope = fnStack[0]
+
+        if (
+          !fnScope ||
+          (!isMdxContent(fnScope.node) && !providerImportSource)
+        ) {
+          return
+        }
+
+        const newScope = /** @type {Scope|undefined} */ (
+          // @ts-expect-error: periscopic doesn’t support JSX.
+          scopeInfo.map.get(node)
+        )
+
+        if (newScope) {
+          newScope.node = node
+          currentScope = newScope
+        }
+
+        if (currentScope && node.type === 'JSXElement') {
+          let name = node.openingElement.name
 
           // `<x.y>`, `<Foo.Bar>`, `<x.y.z>`.
           if (name.type === 'JSXMemberExpression') {
             // Find the left-most identifier.
             while (name.type === 'JSXMemberExpression') name = name.object
 
-            if (
-              !scope.objects.includes(name.name) &&
-              !topScope.has(name.name)
-            ) {
-              scope.objects.push(name.name)
+            const id = name.name
+
+            if (!fnScope.objects.includes(id) && !inScope(currentScope, id)) {
+              fnScope.objects.push(id)
             }
           }
           // `<xml:thing>`.
@@ -88,35 +109,39 @@ export function recmaJsxRewrite(options = {}) {
           // For example, `$foo`, `_bar`, `Baz` are all component names.
           // But `foo` and `b-ar` are tag names.
           else if (isIdentifierName(name.name) && !/^[a-z]/.test(name.name)) {
+            const id = name.name
+
             if (
-              !scope.components.includes(name.name) &&
-              !topScope.has(name.name)
+              !fnScope.components.includes(id) &&
+              !inScope(currentScope, id)
             ) {
-              scope.components.push(name.name)
+              fnScope.components.push(id)
             }
           }
           // @ts-expect-error Allow fields passed through from mdast through hast to
           // esast.
-          else if (element.data && element.data._xdmExplicitJsx) {
+          else if (node.data && node.data._xdmExplicitJsx) {
             // Do not turn explicit JSX into components from `_components`.
             // As in, a given `h1` component is used for `# heading` (next case),
             // but not for `<h1>heading</h1>`.
           } else {
-            if (!scope.tags.includes(name.name)) {
-              scope.tags.push(name.name)
+            const id = name.name
+
+            if (!fnScope.tags.includes(id)) {
+              fnScope.tags.push(id)
             }
 
-            element.openingElement.name = {
+            node.openingElement.name = {
               type: 'JSXMemberExpression',
               object: {type: 'JSXIdentifier', name: '_components'},
               property: name
             }
 
-            if (element.closingElement) {
-              element.closingElement.name = {
+            if (node.closingElement) {
+              node.closingElement.name = {
                 type: 'JSXMemberExpression',
                 object: {type: 'JSXIdentifier', name: '_components'},
-                property: {type: 'JSXIdentifier', name: name.name}
+                property: {type: 'JSXIdentifier', name: id}
               }
             }
           }
@@ -132,19 +157,20 @@ export function recmaJsxRewrite(options = {}) {
         /** @type {Array.<VariableDeclarator>} */
         const declarations = []
 
+        if (currentScope && currentScope.node === node) {
+          // @ts-expect-error: `node`s were patched when entering.
+          currentScope = currentScope.parent
+        }
+
         if (
           node.type === 'FunctionDeclaration' ||
           node.type === 'FunctionExpression' ||
           node.type === 'ArrowFunctionExpression'
         ) {
           const fn = /** @type {ESFunction} */ (node)
-          const scope = stack.pop()
+          const scope = fnStack[fnStack.length - 1]
           /** @type {string} */
           let name
-
-          // Supported for types but our stack is good!
-          /* c8 ignore next 1 */
-          if (!scope) throw new Error('Expected scope on stack')
 
           for (name of scope.tags) {
             defaults.push({
@@ -182,11 +208,7 @@ export function recmaJsxRewrite(options = {}) {
             }
 
             // Accept `components` as a prop if this is the `MDXContent` function.
-            if (
-              fn.type === 'FunctionDeclaration' &&
-              fn.id &&
-              fn.id.name === 'MDXContent'
-            ) {
+            if (isMdxContent(scope.node)) {
               parameters.push({
                 type: 'MemberExpression',
                 object: {type: 'Identifier', name: 'props'},
@@ -199,21 +221,18 @@ export function recmaJsxRewrite(options = {}) {
             declarations.push({
               type: 'VariableDeclarator',
               id: {type: 'Identifier', name: '_components'},
-              init:
-                parameters.length > 1
-                  ? {
-                      type: 'CallExpression',
-                      callee: {
-                        type: 'MemberExpression',
-                        object: {type: 'Identifier', name: 'Object'},
-                        property: {type: 'Identifier', name: 'assign'},
-                        computed: false,
-                        optional: false
-                      },
-                      arguments: parameters,
-                      optional: false
-                    }
-                  : parameters[0]
+              init: {
+                type: 'CallExpression',
+                callee: {
+                  type: 'MemberExpression',
+                  object: {type: 'Identifier', name: 'Object'},
+                  property: {type: 'Identifier', name: 'assign'},
+                  computed: false,
+                  optional: false
+                },
+                arguments: parameters,
+                optional: false
+              }
             })
 
             // Add components to scope.
@@ -259,6 +278,8 @@ export function recmaJsxRewrite(options = {}) {
               declarations
             })
           }
+
+          fnStack.pop()
         }
       }
     })
@@ -310,4 +331,34 @@ function createImportProvider(providerImportSource, outputFormat) {
         specifiers,
         source: {type: 'Literal', value: providerImportSource}
       }
+}
+
+/**
+ * @param {ESFunction} [node]
+ * @returns {boolean}
+ */
+function isMdxContent(node) {
+  return Boolean(
+    node && 'id' in node && node.id && node.id.name === 'MDXContent'
+  )
+}
+
+/**
+ * @param {Scope} scope
+ * @param {string} id
+ */
+function inScope(scope, id) {
+  /** @type {Scope|null} */
+  let currentScope = scope
+
+  while (currentScope) {
+    if (currentScope.declarations.has(id)) {
+      return true
+    }
+
+    // @ts-expect-error: `node`s have been added when entering.
+    currentScope = currentScope.parent
+  }
+
+  return false
 }

--- a/readme.md
+++ b/readme.md
@@ -861,7 +861,7 @@ These do not adhere to semver and could break at any time!
 
 ### Importing `.mdx` files directly
 
-[ESM loaders](https://nodejs.org/api/esm.html#esm_loaders) are an experimental
+[ESM loaders](https://nodejs.org/api/esm.html#esm\_loaders) are an experimental
 feature in Node, slated to change.
 Still, they let projects “hijack” imports, to do all sorts of fancy things!
 **xdm** comes with experimental support for importing `.mdx` files with
@@ -908,7 +908,7 @@ multiple loaders with
 
 ### Requiring `.mdx` files directly
 
-[`require.extensions`](https://nodejs.org/api/modules.html#modules_require_extensions)
+[`require.extensions`](https://nodejs.org/api/modules.html#modules\_require\_extensions)
 is a deprecated feature in Node.
 Still, it lets projects “hijack” `require` calls to do fancy things.
 **xdm** comes with support for requiring `.mdx` files with on-the-fly

--- a/test/core.js
+++ b/test/core.js
@@ -270,8 +270,6 @@ test('xdm', async (t) => {
     'should *not* support overwriting components in exports'
   )
 
-  console.log('\nnote: the next warning is expected!\n')
-
   try {
     renderToStaticMarkup(
       React.createElement(
@@ -283,7 +281,7 @@ test('xdm', async (t) => {
     const exception = /** @type {Error} */ (error)
     t.match(
       exception.message,
-      /Element type is invalid/,
+      /Y is not defined/,
       'should throw on missing components in exported components'
     )
   }
@@ -310,6 +308,20 @@ test('xdm', async (t) => {
     ),
     '<span>!</span>',
     'should support provided components in exported components'
+  )
+
+  t.equal(
+    renderToStaticMarkup(
+      React.createElement(
+        await run(
+          compileSync(
+            'export function Foo({Box = "div"}) { return <Box>a</Box>; }\n\n<Foo />'
+          )
+        )
+      )
+    ),
+    '<div>a</div>',
+    'should support custom components in exported components'
   )
 
   t.equal(


### PR DESCRIPTION
Components defined in MDX content should be able to receive arbitrary
props.
The main `MDXContent` component, though, receives `props.components`.
Previously their was a mix up where the code did not differentiate
between the two.
The handling of whether a variable was defined or not (which is needed
for the rewrite that allows components being passed in and provided
through context) was also too naïve.

This commit fixes that.

Closes GH-53.